### PR TITLE
Set widget in RegistrationForm to PasswordInput.

### DIFF
--- a/corvid/main/forms/registration.py
+++ b/corvid/main/forms/registration.py
@@ -6,3 +6,4 @@ class RegistrationForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ['username', 'email', 'password']
+        widgets = {'password': forms.PasswordInput()}


### PR DESCRIPTION
This fixes issue #28 (caused by Jeff and me) where the password field of the registration form doesn't isn't a password input, and so displays the characters you type.  Really simple fix here.