### PR TITLE
Make admin user actually, you know, an admin.

### DIFF
--- a/corvid/main/management/commands/populate.py
+++ b/corvid/main/management/commands/populate.py
@@ -10,6 +10,9 @@ class Command(BaseCommand):
         admin_user = User.objects.create_user('admin_user',
                                               'admin@example.com',
                                               'cock-of-the-rock')
+        admin_user.is_superuser = True
+        admin_user.is_staff = True
+        admin_user.is_active = True
         admin_user.save()
 
         default_theme = Theme.objects.create(title='default',


### PR DESCRIPTION
The populate script's `admin_user` wasn't actually set to be an admin.  So we've never been able to use the Django administration interface (at `/admin/`).  Since the admin interface is pretty dope, here's a PR to make the admin user actually an admin.  You'll need to either flush and regenerate your database, or open the django shell and set the attributes in my code on whichever user you'd like.