### PR TITLE
Added venv/bin to path for make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PHONY: run migrate test clean
+run: PATH  := venv/bin/:$(PATH)
 run: migrate venv
 	venv/bin/python corvid/manage.py runserver
 


### PR DESCRIPTION
This allows `make run` to work without activating the virtualenv first