### PR TITLE
Catch pelican failures

### DIFF
--- a/corvid/main/views/site_generation.py
+++ b/corvid/main/views/site_generation.py
@@ -7,6 +7,7 @@ from .protected_view import ProtectedViewMixin
 from subprocess import Popen
 from datetime import datetime
 from collections import Counter
+from pprint import pprint
 import tempfile
 import zipfile
 import shutil
@@ -18,7 +19,8 @@ class SiteGenerationView(ProtectedViewMixin, View):
     def get(self, request, *args, **kwargs):
         try:
             return self._do_generate(request, args, kwargs)
-        except:
+        except Exception as e:
+            pprint(e)
             ctx = {
                 'message': "Actually, we derped. You can redeem this"
                            " page for a free hug from the Corvidae. Sorry :(",

--- a/corvid/main/views/site_generation.py
+++ b/corvid/main/views/site_generation.py
@@ -10,7 +10,6 @@ from collections import Counter
 from pprint import pprint
 import tempfile
 import zipfile
-import shutil
 import shlex
 import os
 
@@ -34,7 +33,6 @@ class SiteGenerationView(ProtectedViewMixin, View):
         project = Project.objects.get(owner=request.user, title=project_title)
 
         with tempfile.TemporaryDirectory() as site_dir:
-            print(site_dir)
             with open(os.path.join(site_dir, 'pelicanconf.py'), 'w') as f:
                 f.write(project.get_pelican_conf())
 
@@ -120,10 +118,3 @@ def mkdirs(dir):
     except OSError:
         # if we fail, we don't care
         pass
-
-# TODO: May want a function responding to get for status updates
-'''
-@login_required
-def site_generation_status(request):
-    pass
-'''

--- a/corvid/main/views/site_generation.py
+++ b/corvid/main/views/site_generation.py
@@ -20,9 +20,8 @@ class SiteGenerationView(ProtectedViewMixin, View):
             return self._do_generate(request, args, kwargs)
         except:
             ctx = {
-                'message': "Actually, we derped. Sorry. You can redeem this"
-                           " page for a free hug from a member of the"
-                           " Corvidae.",
+                'message': "Actually, we derped. You can redeem this"
+                           " page for a free hug from the Corvidae. Sorry :(",
                 'link_url': '/project/{0}/{1}'.format(kwargs['owner'], kwargs['proj_title']),
                 'link_text': 'Return to Project Home',
             }
@@ -32,60 +31,58 @@ class SiteGenerationView(ProtectedViewMixin, View):
         project_title = request.resolver_match.kwargs['proj_title']
         project = Project.objects.get(owner=request.user, title=project_title)
 
-        site_dir = tempfile.mkdtemp()
-        with open(os.path.join(site_dir, 'pelicanconf.py'), 'w') as f:
-            f.write(project.get_pelican_conf())
+        with tempfile.TemporaryDirectory() as site_dir:
+            print(site_dir)
+            with open(os.path.join(site_dir, 'pelicanconf.py'), 'w') as f:
+                f.write(project.get_pelican_conf())
 
-        pagelike_counter = Counter()
-        for page in project.page_set.all():
-            page_dir = os.path.join(site_dir, 'content', 'pages')
-            mkdirs(page_dir)
+            pagelike_counter = Counter()
+            for page in project.page_set.all():
+                page_dir = os.path.join(site_dir, 'content', 'pages')
+                mkdirs(page_dir)
 
-            filename = get_filename(page, pagelike_counter)
-            page_file = os.path.join(page_dir, filename) + '.md'
-            with open(page_file, 'w') as f:
-                f.write(page.get_markdown(slug=filename))
+                filename = get_filename(page, pagelike_counter)
+                page_file = os.path.join(page_dir, filename) + '.md'
+                with open(page_file, 'w') as f:
+                    f.write(page.get_markdown(slug=filename))
 
-        for post in project.post_set.all():
-            post_dir = os.path.join(site_dir, 'content', slugify(post.category.title))
-            mkdirs(post_dir)
+            for post in project.post_set.all():
+                post_dir = os.path.join(site_dir, 'content', slugify(post.category.title))
+                mkdirs(post_dir)
 
-            filename = get_filename(post, pagelike_counter)
-            post_file = os.path.join(post_dir, filename) + '.md'
-            with open(post_file, 'w') as f:
-                f.write(post.get_markdown(slug=filename))
+                filename = get_filename(post, pagelike_counter)
+                post_file = os.path.join(post_dir, filename) + '.md'
+                with open(post_file, 'w') as f:
+                    f.write(post.get_markdown(slug=filename))
 
-        # now that we've written out the file, call into pelican
-        returncode = pelican_generate(site_dir, 'content', 'pelicanconf.py')
-        if returncode != 0:
-            raise RuntimeError('Pelican returned status: {0}'.format(returncode))
+            # now that we've written out the file, call into pelican
+            returncode = pelican_generate(site_dir, 'content', 'pelicanconf.py')
+            if returncode != 0:
+                raise RuntimeError('Pelican returned status: {0}'.format(returncode))
 
-        # now zip the output (in RAM)...
-        tempzipfile = tempfile.NamedTemporaryFile(delete=True)
-        output_dir = os.path.join(site_dir, 'output')
+            # now zip the output (in RAM)...
+            tempzipfile = tempfile.NamedTemporaryFile(delete=True)
+            output_dir = os.path.join(site_dir, 'output')
 
-        with zipfile.ZipFile(tempzipfile, 'w', zipfile.ZIP_DEFLATED) as arc:
-            for dirpath, _, filenames in os.walk(output_dir):
-                for filename in filenames:
-                    path = os.path.join(dirpath, filename)
-                    arc_path = os.path.relpath(path, output_dir)
-                    arc.write(path, arc_path)
+            with zipfile.ZipFile(tempzipfile, 'w', zipfile.ZIP_DEFLATED) as arc:
+                for dirpath, _, filenames in os.walk(output_dir):
+                    for filename in filenames:
+                        path = os.path.join(dirpath, filename)
+                        arc_path = os.path.relpath(path, output_dir)
+                        arc.write(path, arc_path)
 
-        # remove the tempdir...
-        shutil.rmtree(site_dir)
+            # load the zipfile's content into memory...
+            with open(tempzipfile.name, 'rb') as f:
+                content = f.read()
+            tempzipfile.close()
 
-        # load the zipfile's content into memory...
-        with open(tempzipfile.name, 'rb') as f:
-            content = f.read()
-        tempzipfile.close()
-
-        # ...and return the zipfile to the user
-        filename = '{0}_output_{1}.zip'.format(project.title,
-                                               datetime.now().strftime('%Y-%m-%d_%H%M'))
-        resp = HttpResponse(content, content_type='application/zip')
-        resp['Content-Disposition'] = 'attachment; filename={0}'.format(filename)
-        resp['Content-Length'] = len(content)
-        return resp
+            # ...and return the zipfile to the user
+            filename = '{0}_output_{1}.zip'.format(project.title,
+                                                   datetime.now().strftime('%Y-%m-%d_%H%M'))
+            resp = HttpResponse(content, content_type='application/zip')
+            resp['Content-Disposition'] = 'attachment; filename={0}'.format(filename)
+            resp['Content-Length'] = len(content)
+            return resp
 
 
 def get_filename(pagelike, pagelike_counter):


### PR DESCRIPTION
Nearly-empty zips replaced with free hugs.

Quick way to test: create a new project w/o pages or posts and try to download the ZIP. You should see the page because Pelican sees an empty content directory and returns status 1.

Resolves #64.