### PR TITLE
Project cloning

### DIFF
--- a/corvid/main/forms/__init__.py
+++ b/corvid/main/forms/__init__.py
@@ -1,2 +1,3 @@
 from .registration import RegistrationForm
 from .create_project import CreateProjectForm
+from .clone_project import CloneProjectForm

--- a/corvid/main/forms/clone_project.py
+++ b/corvid/main/forms/clone_project.py
@@ -7,10 +7,10 @@ from main.models import Project
 class CloneProjectForm(forms.Form):
 
     title = forms.CharField(max_length=50)
-    clone_theme = forms.BooleanField(initial=True)
-    clone_pages = forms.BooleanField(initial=True)
-    clone_posts = forms.BooleanField(initial=True)
-    clone_plugins = forms.BooleanField(initial=True)
+    clone_theme = forms.BooleanField(initial=True, required=False)
+    clone_pages = forms.BooleanField(initial=True, required=False)
+    clone_posts = forms.BooleanField(initial=True, required=False)
+    clone_plugins = forms.BooleanField(initial=True, required=False)
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')

--- a/corvid/main/forms/clone_project.py
+++ b/corvid/main/forms/clone_project.py
@@ -1,0 +1,31 @@
+from django import forms
+from django.core.exceptions import ValidationError
+
+from main.models import Project
+
+
+class CloneProjectForm(forms.Form):
+
+    title = forms.CharField(max_length=50)
+    clone_theme = forms.BooleanField(initial=True)
+    clone_pages = forms.BooleanField(initial=True)
+    clone_posts = forms.BooleanField(initial=True)
+    clone_plugins = forms.BooleanField(initial=True)
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user')
+        super().__init__(*args, **kwargs)
+
+    def clean_title(self):
+        # Validation - make sure this is the only project with that title by
+        # that user.
+        if len(Project.objects.filter(owner=self.user,
+                                      title=self.cleaned_data['title'])) > 0:
+            raise ValidationError('Project with that name already exists.')
+
+        # More validation - make sure this title has no forward slashes:
+        if '/' in self.cleaned_data['title']:
+            raise ValidationError('Project title may not contain forward slash'
+                                  ' ("/").')
+
+        return self.cleaned_data['title']

--- a/corvid/main/models/category.py
+++ b/corvid/main/models/category.py
@@ -14,6 +14,7 @@ class Category(models.Model):
         return self.title
 
     def clone(self, newproject):
+        """Clone this category into a new project."""
         new = Category.objects.create(title=self.title, project=newproject)
         new.save()
         return new

--- a/corvid/main/models/category.py
+++ b/corvid/main/models/category.py
@@ -12,3 +12,8 @@ class Category(models.Model):
 
     def __str__(self):
         return self.title
+
+    def clone(self, newproject):
+        new = Category.objects.create(title=self.title, project=newproject)
+        new.save()
+        return new

--- a/corvid/main/models/page.py
+++ b/corvid/main/models/page.py
@@ -20,6 +20,21 @@ class Page(models.Model):
             'slug': slug if slug else self.title
         })
 
+    def clone(self, newproject, plugins):
+        kwargs = {
+            'title': self.title,
+            'content': self.content,
+            'project': newproject,
+        }
+        new = Page.objects.create(**kwargs)
+
+        if plugins:
+            for plugin in self.post_plugins:
+                new.post_plugins.add(plugins[plugin])
+
+        new.save()
+        return new
+
 
 page_template = """Title: %(title)s
 Slug: %(slug)s

--- a/corvid/main/models/page.py
+++ b/corvid/main/models/page.py
@@ -21,6 +21,13 @@ class Page(models.Model):
         })
 
     def clone(self, newproject, plugins):
+        """
+        Clones this Page into a new project.
+        :param newproject: The new project to stick this one into.
+        :param plugins: Either None (if plugins are not being cloned), or a
+          dictionary mapping old plugins to plugins in the new project.
+        :return: The new page (already saved to database)
+        """
         kwargs = {
             'title': self.title,
             'content': self.content,

--- a/corvid/main/models/page.py
+++ b/corvid/main/models/page.py
@@ -29,7 +29,7 @@ class Page(models.Model):
         new = Page.objects.create(**kwargs)
 
         if plugins:
-            for plugin in self.post_plugins:
+            for plugin in self.post_plugins.all():
                 new.post_plugins.add(plugins[plugin])
 
         new.save()

--- a/corvid/main/models/page_plugin.py
+++ b/corvid/main/models/page_plugin.py
@@ -11,3 +11,14 @@ class PagePlugin(models.Model):
     body_markup = models.CharField(max_length=5000)
 
     project = models.ForeignKey('Project')
+
+    def clone(self, newproject):
+        kwargs = {
+            'title': self.title,
+            'head_markup': self.head_markup,
+            'body_markup': self.body_markup,
+            'project': newproject,
+        }
+        new = PagePlugin.objects.create(**kwargs)
+        new.save()
+        return new

--- a/corvid/main/models/page_plugin.py
+++ b/corvid/main/models/page_plugin.py
@@ -13,6 +13,7 @@ class PagePlugin(models.Model):
     project = models.ForeignKey('Project')
 
     def clone(self, newproject):
+        """Clone the plugin into a new project."""
         kwargs = {
             'title': self.title,
             'head_markup': self.head_markup,

--- a/corvid/main/models/post.py
+++ b/corvid/main/models/post.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.utils.text import slugify
 
+from main.models import Category
+
 
 class Post(models.Model):
     title = models.CharField(max_length=50)
@@ -35,6 +37,26 @@ class Post(models.Model):
             kwargs['date_modified_str'] = ('Modified: {0}\n'
                                            .format(self.date_updated.strftime(date_fmt)))
         return (post_template % kwargs)
+
+    def clone(self, newproject, plugins):
+        category = Category.objects.get(project=newproject,
+                                        title=self.category.title)
+        kwargs = {
+            'title': self.title,
+            'content': self.content,
+            'date_created': self.date_created,
+            'date_updated': self.date_updated,
+            'project': newproject,
+            'category': category,
+        }
+        new = Post.objects.create(**kwargs)
+
+        if plugins:
+            for plugin in self.post_plugins:
+                new.post_plugins.add(plugins[plugin])
+
+        new.save()
+        return new
 
 
 post_template = """Title: %(title)s

--- a/corvid/main/models/post.py
+++ b/corvid/main/models/post.py
@@ -39,6 +39,13 @@ class Post(models.Model):
         return (post_template % kwargs)
 
     def clone(self, newproject, plugins):
+        """
+        Clones this Post into a new project.
+        :param newproject: The new project to stick this one into.
+        :param plugins: Either None (if plugins are not being cloned), or a
+          dictionary mapping old plugins to plugins in the new project.
+        :return: The new post (already saved to database)
+        """
         category = Category.objects.get(project=newproject,
                                         title=self.category.title)
         kwargs = {

--- a/corvid/main/models/post.py
+++ b/corvid/main/models/post.py
@@ -52,7 +52,7 @@ class Post(models.Model):
         new = Post.objects.create(**kwargs)
 
         if plugins:
-            for plugin in self.post_plugins:
+            for plugin in self.post_plugins.all():
                 new.post_plugins.add(plugins[plugin])
 
         new.save()

--- a/corvid/main/models/project.py
+++ b/corvid/main/models/project.py
@@ -2,7 +2,9 @@
 Represents a project: a static website.
 """
 from django.db import models
+
 from .user import User
+from .theme import Theme
 
 
 class Project(models.Model):
@@ -33,6 +35,46 @@ class Project(models.Model):
             'theme': self.theme.filepath,
         }
         return pelicanconf_template % template_args
+
+    def clone(self, newtitle, theme, pages, posts, plugins):
+        kwargs = {
+            'title': newtitle,
+            'description': self.description,
+            'owner': self.owner,
+            'preview_url': '',
+        }
+        if theme:
+            kwargs['theme'] = self.theme
+        else:
+            kwargs['theme'] = Theme.objects.get(title='default')
+
+        new = Project.objects.create(**kwargs)
+        new.save()
+
+        # Copy over all the categories.
+        for category in self.category_set.all():
+            category.clone(new)
+
+        # First, we clone all the plugins.  We keep a dictionary of page for
+        # our pages and posts to lookup their new plugins when they are cloned.
+        if plugins:
+            plugin_dict = {}
+            for plugin in self.pageplugin_set.all():
+                plugin_dict[plugin] = plugin.clone(new)
+            for plugin in self.projectplugin_set.all():
+                plugin.clone(new)
+        else:
+            plugin_dict = None
+
+        # Now, we clone pages and posts (if requested)
+        if pages:
+            for page in self.page_set.all():
+                page.clone(new, plugin_dict)
+        if posts:
+            for post in self.post_set.all():
+                post.clone(new, plugin_dict)
+
+        return new
 
 
 pelicanconf_template = """#!/usr/bin/env python

--- a/corvid/main/models/project.py
+++ b/corvid/main/models/project.py
@@ -37,6 +37,15 @@ class Project(models.Model):
         return pelicanconf_template % template_args
 
     def clone(self, newtitle, theme, pages, posts, plugins):
+        """
+        Clone this project.
+
+        Creates a new project with the same attributes and owner, but a
+        different title.  Depending on the parameters given to this method, the
+        theme, pages, posts, and/or plugins will also be copied to the new
+        project.  Returns the cloned project, which has already been saved to
+        the database.
+        """
         kwargs = {
             'title': newtitle,
             'description': self.description,

--- a/corvid/main/models/project_plugin.py
+++ b/corvid/main/models/project_plugin.py
@@ -12,6 +12,7 @@ class ProjectPlugin(models.Model):
     project = models.ForeignKey('Project')
 
     def clone(self, newproject):
+        """Clone the plugin into a new project."""
         kwargs = {
             'title': self.title,
             'markup': self.markup,

--- a/corvid/main/models/project_plugin.py
+++ b/corvid/main/models/project_plugin.py
@@ -10,3 +10,13 @@ class ProjectPlugin(models.Model):
     markup = models.CharField(max_length=5000)
 
     project = models.ForeignKey('Project')
+
+    def clone(self, newproject):
+        kwargs = {
+            'title': self.title,
+            'markup': self.markup,
+            'project': newproject,
+        }
+        new = ProjectPlugin.objects.create(**kwargs)
+        new.save()
+        return new

--- a/corvid/main/templates/account_home.html
+++ b/corvid/main/templates/account_home.html
@@ -1,11 +1,28 @@
 {% extends 'base.html' %}
 {% block content %}
-<h1>Account Home</h1>
-<h3>Projects:</h3>
-<ul style='list-style-type:none'>
-    {% for project in object_list %}
-    <li><a href='{{ project.project_home_url }}'>{{ project.title }}</li>
-    {% endfor %}
-</ul>
-<a href='{% url 'new_project' %}'>New Project</a>
+<div class='col-md-6 col-md-offset-3 text-left'>
+  <h1>Account Home</h1>
+    <div class='panel panel-default'>
+        <div class='panel-heading'>
+            <h2 class='panel-title'>Projects</h2>
+        </div>
+        <ul class='list-group'>
+            {% for project in object_list %}
+            <li class='list-group-item'>
+                <a class='actions' href="{% url 'project_home' owner=project.owner.username title=project.title %}">
+                    <span class='pp-title'>{{ project.title }}</span></a>
+                <div class='go-right'>
+                    <a href="{% url 'clone_project' owner=project.owner.username title=project.title %}" title="Clone Project">
+                        <span class='glyphicon glyphicon-duplicate actions'></span></a>
+                    <a href="{% url 'delete_project' owner=project.owner.username title=project.title %}" title="Delete Project">
+                        <span class='glyphicon glyphicon-trash actions'></span></a>
+                </div>
+            </li>
+            {% endfor %}
+            <li class='list-group-item'>
+                <a class='actions' href="{% url 'new_project' %}"><span class='glyphicon glyphicon-plus'></span> New Project</a>
+            </li>
+        </ul>
+    </div>
+</div>
 {% endblock %}

--- a/corvid/main/templates/project_clone.html
+++ b/corvid/main/templates/project_clone.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% load bootstrap_tags %}
+{% block content %}
+<div class='std-form'>
+<h1>Clone Project</h1>
+<form action="#" method="post">
+    {% csrf_token %}
+    {{ form|as_bootstrap }}
+    <input type="submit" class='btn btn-primary' value="Create" />
+    <a class='btn btn-default' href='{% url "home" %}'>Cancel</a>
+</form>
+{% endblock %}

--- a/corvid/main/templates/project_clone.html
+++ b/corvid/main/templates/project_clone.html
@@ -2,11 +2,11 @@
 {% load bootstrap_tags %}
 {% block content %}
 <div class='std-form'>
-<h1>Clone Project</h1>
+<h1>Clone {{project}}</h1>
 <form action="#" method="post">
     {% csrf_token %}
     {{ form|as_bootstrap }}
-    <input type="submit" class='btn btn-primary' value="Create" />
+    <input type="submit" class='btn btn-primary' value="Clone" />
     <a class='btn btn-default' href='{% url "home" %}'>Cancel</a>
 </form>
 {% endblock %}

--- a/corvid/main/templates/project_home.html
+++ b/corvid/main/templates/project_home.html
@@ -28,7 +28,6 @@
         </ul>
     </div>
     <a class='actions' href='{% url 'project_settings' owner=owner title=title %}'><span class='glyphicon glyphicon-cog'></span> Project Settings</a>
-    <a class='actions' href='{% url 'delete_project' owner=owner title=title %}'><span class='glyphicon glyphicon-trash'></span> Delete Project</a>
 </div>
 <div class='col-md-6 text-left'>
     <div class='panel panel-default'>
@@ -41,9 +40,9 @@
                 <a class='actions' href="{% url 'edit_page' owner=owner proj_title=title page_id=page.id %}">
                     <span class='pp-title'>{{ page.title }}</span></a>
                 <div class='go-right'>
-                    <a href="{% url 'edit_page' owner=owner proj_title=title page_id=page.id %}">
+                    <a href="{% url 'edit_page' owner=owner proj_title=title page_id=page.id %}" title="Edit Page">
                         <span class='glyphicon glyphicon-edit actions'></span></a>
-                    <a href="{% url 'delete_page' owner=owner proj_title=title page_id=page.id %}">
+                    <a href="{% url 'delete_page' owner=owner proj_title=title page_id=page.id %}" title="Delete Page">
                         <span class='glyphicon glyphicon-trash actions'></span></a>
                 </div>
             </li>
@@ -68,9 +67,9 @@
                 <a class='label label-info' href='{% url 'edit_category' owner=owner title=title category_id=post.category.id %}'>{{ post.category }}</a>
                 {% endif %}
                 <div class='go-right'>
-                    <a href="{% url 'edit_post' owner=owner proj_title=title post_id=post.id %}">
+                    <a href="{% url 'edit_post' owner=owner proj_title=title post_id=post.id %}" title="Edit Post">
                         <span class='glyphicon glyphicon-edit actions'></span></a>
-                    <a href="{% url 'delete_post' owner=owner proj_title=title post_id=post.id %}">
+                    <a href="{% url 'delete_post' owner=owner proj_title=title post_id=post.id %}" title="Delete Post">
                         <span class='glyphicon glyphicon-trash actions'></span></a>
                 </div>
             </li>

--- a/corvid/main/templates/project_settings.html
+++ b/corvid/main/templates/project_settings.html
@@ -9,6 +9,5 @@
     <input type='submit' class='btn btn-primary' name='create_account' value='Submit'/>
     <a class='btn btn-default' href='{% url "project_home" owner=user.username title=project %}'>Cancel</a>
 </form>
-<a class='btn btn-default' href='{% url "clone_project" owner=user.username title=project %}'>Clone Project</a>
 </div>
 {% endblock %}

--- a/corvid/main/templates/project_settings.html
+++ b/corvid/main/templates/project_settings.html
@@ -9,5 +9,6 @@
     <input type='submit' class='btn btn-primary' name='create_account' value='Submit'/>
     <a class='btn btn-default' href='{% url "project_home" owner=user.username title=project %}'>Cancel</a>
 </form>
+<a class='btn btn-default' href='{% url "clone_project" owner=user.username title=project %}'>Clone Project</a>
 </div>
 {% endblock %}

--- a/corvid/main/tests/test_cloning.py
+++ b/corvid/main/tests/test_cloning.py
@@ -1,0 +1,302 @@
+"""
+Tests for cloning projects.
+"""
+
+from django.utils import timezone
+
+from .base import CorvidTestCase
+from main.models import (Project, Page, Post, Category, Theme, ProjectPlugin,
+                         PagePlugin)
+
+
+class CloneProjectTestCase(CorvidTestCase):
+
+    def setUp(self):
+        super().setUpTheme()
+
+        # A "new theme" so we can test theme cloning.
+        self.other_theme = Theme.objects.create(title='other',
+                                                filepath='html5dopetrope',
+                                                creator=self.admin_user)
+        self.other_theme.save()
+
+        # A project to clone.
+        self.project = Project.objects.create(
+            title='project', description='test project', preview_url='',
+            owner=self.admin_user, theme=self.other_theme
+        )
+        self.project.save()
+
+        # Some plugins
+        self.page_plugin = PagePlugin.objects.create(
+            title='page plugin', head_markup='<script>alert("hi")</script>',
+            body_markup='<h1>I\'m a plugin!</h1>', project=self.project
+        )
+        self.page_plugin.save()
+
+        self.project_plugin = ProjectPlugin.objects.create(
+            title='project plugin',
+            markup='<script>alert("project_plugin")</script>',
+            project=self.project
+        )
+        self.project_plugin.save()
+
+        # Some categories
+        self.category_one = Category.objects.create(
+            title='category1', project=self.project
+        )
+        self.category_one.save()
+
+        self.category_two = Category.objects.create(
+            title='category2', project=self.project
+        )
+        self.category_two.save()
+
+        # And some pages and posts
+        self.page_one = Page.objects.create(
+            title='Home',
+            content='Welcome to the test project (it\'s been waiting for you)',
+            project=self.project
+        )
+        self.page_one.save()
+        self.page_one.post_plugins.add(self.page_plugin)
+        self.page_one.save()  # probably unnecessary
+
+        self.page_two = Page.objects.create(
+            title='About', content='I\'m a page!', project=self.project
+        )
+        self.page_one.save()
+
+        self.post_one = Post.objects.create(
+            title='First Post',
+            content='Do you have a moment to talk about our lord and Savior, '
+            'Pelican?',
+            project=self.project, category=self.category_one,
+            date_created=timezone.now(), date_updated=timezone.now()
+        )
+        self.post_one.save()
+        self.post_one.post_plugins.add(self.page_plugin)
+        self.post_one.save()  # probably unnecessary
+
+        self.post_two = Post.objects.create(
+            title='Second Post', content='I\'m a post!', project=self.project,
+            category=self.category_two, date_created=timezone.now(),
+            date_updated=timezone.now()
+        )
+        self.post_one.save()
+
+    def tearDown(self):
+        super().tearDownTheme()
+
+    def test_clone_nothing(self):
+        new = self.project.clone('cloned', False, False, False, False)
+        # Assert that attributes were cloned properly.
+        self.assertEqual(new.title, 'cloned')
+        self.assertEqual(new.description, self.project.description)
+        self.assertEqual(new.preview_url, self.project.preview_url)
+        self.assertEqual(new.owner, self.project.owner)
+
+        # Categories are cloned
+        self.assertEqual(new.category_set.count(), 2)
+        self.assertEqual(new.category_set.filter(title=self.category_one.title).count(), 1)
+        self.assertEqual(new.category_set.filter(title=self.category_two.title).count(), 1)
+
+        # Assert that the theme was not cloned.
+        self.assertNotEqual(new.theme, self.project.theme)
+        self.assertEqual(new.theme, self.default_theme)
+
+        # Assert that the pages, posts, and plugins were not cloned.
+        self.assertEqual(new.page_set.count(), 0)
+        self.assertEqual(new.post_set.count(), 0)
+        self.assertEqual(new.pageplugin_set.count(), 0)
+        self.assertEqual(new.projectplugin_set.count(), 0)
+
+    def test_clone_theme(self):
+        new = self.project.clone('cloned', True, False, False, False)
+        # Assert that attributes were cloned properly.
+        self.assertEqual(new.title, 'cloned')
+        self.assertEqual(new.description, self.project.description)
+        self.assertEqual(new.preview_url, self.project.preview_url)
+        self.assertEqual(new.owner, self.project.owner)
+
+        # Categories are cloned
+        self.assertEqual(new.category_set.count(), 2)
+        self.assertEqual(new.category_set.filter(title=self.category_one.title).count(), 1)
+        self.assertEqual(new.category_set.filter(title=self.category_two.title).count(), 1)
+
+        # Assert that the theme was cloned.
+        self.assertEqual(new.theme, self.project.theme)
+
+        # Assert that the pages, posts, and plugins were not cloned.
+        self.assertEqual(new.page_set.count(), 0)
+        self.assertEqual(new.post_set.count(), 0)
+        self.assertEqual(new.pageplugin_set.count(), 0)
+        self.assertEqual(new.projectplugin_set.count(), 0)
+
+    def test_clone_pages(self):
+        new = self.project.clone('cloned', False, True, False, False)
+        # Assert that attributes were cloned properly.
+        self.assertEqual(new.title, 'cloned')
+        self.assertEqual(new.description, self.project.description)
+        self.assertEqual(new.preview_url, self.project.preview_url)
+        self.assertEqual(new.owner, self.project.owner)
+
+        # Categories are cloned
+        self.assertEqual(new.category_set.count(), 2)
+        self.assertEqual(new.category_set.filter(title=self.category_one.title).count(), 1)
+        self.assertEqual(new.category_set.filter(title=self.category_two.title).count(), 1)
+
+        # Assert that the theme was not cloned.
+        self.assertNotEqual(new.theme, self.project.theme)
+        self.assertEqual(new.theme, self.default_theme)
+
+        # Assert that the posts and plugins were not cloned.
+        self.assertEqual(new.post_set.count(), 0)
+        self.assertEqual(new.pageplugin_set.count(), 0)
+        self.assertEqual(new.projectplugin_set.count(), 0)
+
+        # Assert that the pages were cloned.
+        self.assertEqual(new.page_set.count(), 2)
+        p1 = new.page_set.get(title=self.page_one.title)
+        self.assertEqual(p1.title, self.page_one.title)
+        self.assertEqual(p1.content, self.page_one.content)
+        self.assertEqual(p1.project, new)
+        p2 = new.page_set.get(title=self.page_two.title)
+        self.assertEqual(p2.title, self.page_two.title)
+        self.assertEqual(p2.content, self.page_two.content)
+        self.assertEqual(p2.project, new)
+
+        # Since the plugins were not cloned, p1 and p2 will not have any!
+        self.assertEqual(p1.post_plugins.count(), 0)
+        self.assertEqual(p2.post_plugins.count(), 0)
+
+    def test_clone_posts(self):
+        new = self.project.clone('cloned', False, False, True, False)
+        # Assert that attributes were cloned properly.
+        self.assertEqual(new.title, 'cloned')
+        self.assertEqual(new.description, self.project.description)
+        self.assertEqual(new.preview_url, self.project.preview_url)
+        self.assertEqual(new.owner, self.project.owner)
+
+        # Assert that the theme was not cloned.
+        self.assertNotEqual(new.theme, self.project.theme)
+        self.assertEqual(new.theme, self.default_theme)
+
+        # Assert that the pages and plugins were not cloned.
+        self.assertEqual(new.page_set.count(), 0)
+        self.assertEqual(new.pageplugin_set.count(), 0)
+        self.assertEqual(new.projectplugin_set.count(), 0)
+
+        # Assert that the posts were cloned.
+        self.assertEqual(new.post_set.count(), 2)
+        p1 = new.post_set.get(title=self.post_one.title)
+        self.assertEqual(p1.title, self.post_one.title)
+        self.assertEqual(p1.content, self.post_one.content)
+        self.assertEqual(p1.date_created, self.post_one.date_created)
+        self.assertEqual(p1.date_updated, self.post_one.date_updated)
+        self.assertNotEqual(p1.category, self.post_one.category)
+        self.assertEqual(p1.category.title, self.post_one.category.title)
+        self.assertEqual(p1.project, new)
+        p2 = new.post_set.get(title=self.post_two.title)
+        self.assertEqual(p2.title, self.post_two.title)
+        self.assertEqual(p2.content, self.post_two.content)
+        self.assertEqual(p2.date_created, self.post_two.date_created)
+        self.assertEqual(p2.date_updated, self.post_two.date_updated)
+        self.assertNotEqual(p2.category, self.post_two.category)
+        self.assertEqual(p2.category.title, self.post_two.category.title)
+        self.assertEqual(p2.project, new)
+
+        # Since plugins weren't cloned, none of them have plugins.
+        self.assertEqual(p1.post_plugins.count(), 0)
+        self.assertEqual(p2.post_plugins.count(), 0)
+
+    def test_clone_plugins(self):
+        new = self.project.clone('cloned', False, False, False, True)
+        # Assert that attributes were cloned properly.
+        self.assertEqual(new.title, 'cloned')
+        self.assertEqual(new.description, self.project.description)
+        self.assertEqual(new.preview_url, self.project.preview_url)
+        self.assertEqual(new.owner, self.project.owner)
+
+        # Categories are cloned
+        self.assertEqual(new.category_set.count(), 2)
+        self.assertEqual(new.category_set.filter(title=self.category_one.title).count(), 1)
+        self.assertEqual(new.category_set.filter(title=self.category_two.title).count(), 1)
+
+        # Assert that the theme was not cloned.
+        self.assertNotEqual(new.theme, self.project.theme)
+        self.assertEqual(new.theme, self.default_theme)
+
+        # Assert that the pages and posts were not cloned.
+        self.assertEqual(new.page_set.count(), 0)
+        self.assertEqual(new.post_set.count(), 0)
+
+        # Assert that plugins are cloned.
+        self.assertEqual(new.pageplugin_set.count(), 1)
+        p = new.pageplugin_set.get(title=self.page_plugin.title)
+        self.assertEqual(p.head_markup, self.page_plugin.head_markup)
+        self.assertEqual(p.body_markup, self.page_plugin.body_markup)
+        self.assertEqual(p.project, new)
+        self.assertEqual(new.projectplugin_set.count(), 1)
+        p = new.projectplugin_set.get(title=self.project_plugin.title)
+        self.assertEqual(p.markup, self.project_plugin.markup)
+        self.assertEqual(p.project, new)
+
+    def test_clone_all(self):
+        new = self.project.clone('cloned', True, True, True, True)
+        # Assert that attributes were cloned properly.
+        self.assertEqual(new.title, 'cloned')
+        self.assertEqual(new.description, self.project.description)
+        self.assertEqual(new.preview_url, self.project.preview_url)
+        self.assertEqual(new.owner, self.project.owner)
+
+        # Assert that the theme was cloned.
+        self.assertEqual(new.theme, self.project.theme)
+
+        # Assert that plugins are cloned.
+        self.assertEqual(new.pageplugin_set.count(), 1)
+        p = new.pageplugin_set.get(title=self.page_plugin.title)
+        self.assertEqual(p.head_markup, self.page_plugin.head_markup)
+        self.assertEqual(p.body_markup, self.page_plugin.body_markup)
+        self.assertEqual(p.project, new)
+        self.assertEqual(new.projectplugin_set.count(), 1)
+        p = new.projectplugin_set.get(title=self.project_plugin.title)
+        self.assertEqual(p.markup, self.project_plugin.markup)
+        self.assertEqual(p.project, new)
+
+        # Assert that the pages were cloned.
+        self.assertEqual(new.page_set.count(), 2)
+        p1 = new.page_set.get(title=self.page_one.title)
+        self.assertEqual(p1.title, self.page_one.title)
+        self.assertEqual(p1.content, self.page_one.content)
+        self.assertEqual(p1.project, new)
+        p2 = new.page_set.get(title=self.page_two.title)
+        self.assertEqual(p2.title, self.page_two.title)
+        self.assertEqual(p2.content, self.page_two.content)
+        self.assertEqual(p2.project, new)
+        # Since the plugins were cloned, they will have the same amount
+        self.assertEqual(p1.post_plugins.count(), self.page_one.post_plugins.count())
+        self.assertEqual(p2.post_plugins.count(), self.page_two.post_plugins.count())
+
+        # Assert that the posts were cloned.
+        self.assertEqual(new.post_set.count(), 2)
+        p1 = new.post_set.get(title=self.post_one.title)
+        self.assertEqual(p1.title, self.post_one.title)
+        self.assertEqual(p1.content, self.post_one.content)
+        self.assertEqual(p1.date_created, self.post_one.date_created)
+        self.assertEqual(p1.date_updated, self.post_one.date_updated)
+        self.assertNotEqual(p1.category, self.post_one.category)
+        self.assertEqual(p1.category.title, self.post_one.category.title)
+        self.assertEqual(p1.project, new)
+        p2 = new.post_set.get(title=self.post_two.title)
+        self.assertEqual(p2.title, self.post_two.title)
+        self.assertEqual(p2.content, self.post_two.content)
+        self.assertEqual(p2.date_created, self.post_two.date_created)
+        self.assertEqual(p2.date_updated, self.post_two.date_updated)
+        self.assertNotEqual(p2.category, self.post_two.category)
+        self.assertEqual(p2.category.title, self.post_two.category.title)
+        self.assertEqual(p2.project, new)
+        # Since plugins were cloned, they will have the same amount.
+        self.assertEqual(p1.post_plugins.count(), self.post_one.post_plugins.count())
+        self.assertEqual(p2.post_plugins.count(), self.post_two.post_plugins.count())
+

--- a/corvid/main/tests/test_project_view.py
+++ b/corvid/main/tests/test_project_view.py
@@ -12,6 +12,18 @@ CreateProjectViewTestCase:
     - empty project name?
     - empty description?
     - invalid names?
+CloneProjectViewTestCase:
+- GET:
+  - not logged in user redirected to login
+  - non-owner cannot access form
+  - user can access form
+- POST:
+  - not logged in user redirected to login
+  - non-owner cannot clone
+  - user can create project
+    - empty project name?
+    - empty description?
+    - invalid names?
 DeleteProjectTestCase:
 - GET:
   - not logged in user redirected to login
@@ -112,6 +124,113 @@ class CreateProjectViewTestCase(CorvidTestCase):
         self.assertEqual(old_number_of_projects, new_number_of_projects)
 
 
+class CloneProjectTestCase(CorvidTestCase):
+
+    def setUp(self):
+        super().setUpTheme()
+        self.client = Client()
+
+        self.otherpass = 'cock-of-the-rock'
+        self.otheruser = User.objects.create_user('other_user',
+                                                  'other@example.com',
+                                                  self.otherpass)
+        self.otheruser.save()
+        self.project = Project.objects.create(
+            title='testproj', description='test project', preview_url='',
+            owner=self.admin_user, theme=self.default_theme
+        )
+        self.project.save()
+
+    def tearDown(self):
+        self.project.delete()
+        self.otheruser.delete()
+        super().tearDownTheme()
+
+    def url_for(self, project):
+        # return the "delete project" url for a project
+        return '/project/%s/%s/clone' % (project.owner.username,
+                                         project.title)
+
+    def login_other(self):
+        # login the client as "otheruser"
+        self.client.login(username=self.otheruser.username,
+                          password=self.otherpass)
+
+    def test_get_not_logged_in_redirect(self):
+        url = self.url_for(self.project)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, 'http://testserver/login/?next=' + url)
+
+    def test_get_not_owner_404(self):
+        url = self.url_for(self.project)
+        self.login_other()
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_get_owner(self):
+        url = self.url_for(self.project)
+        self.login()
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        content = resp.content.decode('utf8')
+        self.assertIn('Clone ' + self.project.title, content)
+
+    def test_post_not_logged_in_redirect(self):
+        formdata = {'title': 'cloned'}
+        url = self.url_for(self.project)
+        resp = self.client.post(url, formdata)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, 'http://testserver/login/?next=' + url)
+
+    def test_post_not_owner_404(self):
+        formdata = {'title': 'cloned'}
+        url = self.url_for(self.project)
+        self.login_other()
+        response = self.client.post(url, formdata)
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_owner(self):
+        formdata = {'title': 'cloned'}
+        url = self.url_for(self.project)
+        self.login()
+        resp = self.client.post(url, formdata)
+        # should get a 200,
+        self.assertEqual(resp.status_code, 200)
+        # Assert that the change happened.
+        matching_projects = Project.objects.filter(owner=self.admin_user,
+                                                   title='cloned')
+        self.assertEqual(len(matching_projects), 1)
+        # Clean it up.
+        matching_projects[0].delete()
+
+    def test_get_invalid_user(self):
+        url = '/project/idontexist/%s/clone' % self.project.title
+        self.login()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_invalid_user(self):
+        formdata = {'title': 'cloned'}
+        url = '/project/idontexist/%s/clone' % self.project.title
+        self.login()
+        response = self.client.post(url, formdata)
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_invalid_project(self):
+        url = '/project/%s/idontexist/clone' % self.admin_user.username
+        self.login()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_invalid_project(self):
+        formdata = {'title': 'cloned'}
+        url = '/project/%s/idontexist/clone' % self.admin_user.username
+        self.login()
+        response = self.client.post(url, formdata)
+        self.assertEqual(response.status_code, 404)
+
+
 class DeleteProjectTestCase(CorvidTestCase):
 
     def setUp(self):
@@ -131,6 +250,7 @@ class DeleteProjectTestCase(CorvidTestCase):
 
     def tearDown(self):
         self.project.delete()
+        self.otheruser.delete()
         super().tearDownTheme()
 
     def url_for(self, project):

--- a/corvid/main/urls.py
+++ b/corvid/main/urls.py
@@ -5,7 +5,7 @@ from .views import (root_controller, UserHomeView, RegistrationView,
                     CreatePostView, UpdatePostView, DeletePostView,
                     ProjectDetailView, SiteGenerationView,
                     CreateCategoryView, UpdateCategoryView, DeleteCategoryView,
-                    ProjectSettingsView)
+                    ProjectSettingsView, CloneProjectView)
 from .views.unauthenticated import login_unrequired
 from django.contrib.auth.views import login as login_view
 from django.contrib.auth.views import logout_then_login as logout_view
@@ -26,6 +26,8 @@ urlpatterns = [
         ProjectSettingsView.as_view(), name='project_settings'),
     url(r'^project/(?P<owner>[^/]+)/(?P<title>[^/]+)/?$',
         ProjectDetailView.as_view(), name='project_home'),
+    url(r'^project/(?P<owner>[^/]+)/(?P<title>[^/]+)/clone/?$',
+        CloneProjectView.as_view(), name='clone_project'),
 
     # Category URLs
     url(r'^project/(?P<owner>[^/]+)/(?P<title>[^/]+)/category/new',

--- a/corvid/main/views/__init__.py
+++ b/corvid/main/views/__init__.py
@@ -1,5 +1,5 @@
 from .category import CreateCategoryView, DeleteCategoryView, UpdateCategoryView
-from .project import CreateProjectView, DeleteProjectView
+from .project import CreateProjectView, DeleteProjectView, CloneProjectView
 from .page import CreatePageView, DeletePageView, UpdatePageView
 from .post import CreatePostView, DeletePostView, UpdatePostView
 from .project_home import ProjectDetailView

--- a/corvid/main/views/project.py
+++ b/corvid/main/views/project.py
@@ -58,6 +58,21 @@ class CloneProjectView(ProtectedViewMixin, FormView):
         kwargs.update({'user': self.request.user})
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # These just ensure that we will 404 if:
+        # - the user doesn't exist
+        # - the project doesn't exist
+        # - the project isn't owned by the user
+        user = get_object_or_404(User.objects, username=self.kwargs['owner'])
+        projectqs = Project.objects.filter(owner=self.request.user)
+        project = get_object_or_404(projectqs, owner=user,
+                                    title=self.kwargs['title'])
+
+        context['project'] = self.kwargs['title']
+        return context
+
     def form_valid(self, form):
         user = get_object_or_404(User.objects, username=self.kwargs['owner'])
         projectqs = Project.objects.filter(owner=self.request.user)

--- a/corvid/main/views/project.py
+++ b/corvid/main/views/project.py
@@ -79,7 +79,6 @@ class CloneProjectView(ProtectedViewMixin, FormView):
         project = get_object_or_404(projectqs, owner=user,
                                     title=self.kwargs['title'])
         data = form.cleaned_data
-        print(data)
         project.clone(data['title'], data['clone_theme'], data['clone_pages'],
                       data['clone_posts'], data['clone_plugins'])
         ctx = {

--- a/corvid/main/views/project.py
+++ b/corvid/main/views/project.py
@@ -4,7 +4,7 @@ from django.template.response import TemplateResponse
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
 from main.models import Project, Theme, User
-from main.forms import CreateProjectForm
+from main.forms import CreateProjectForm, CloneProjectForm
 from .protected_view import ProtectedViewMixin
 
 
@@ -41,6 +41,38 @@ class CreateProjectView(ProtectedViewMixin, FormView):
             'success_message': 'Project created!',
             'return_message': 'Project home',
             'return_url': reverse('project_home', kwargs={'owner': user.username, 'title': title}),
+        }
+        return TemplateResponse(self.request, 'success.html', context=ctx)
+
+
+class CloneProjectView(ProtectedViewMixin, FormView):
+    form_class = CloneProjectForm
+    template_name = 'project_clone.html'
+    default_theme = Theme.objects.get(title='default')
+
+    def get_form_kwargs(self):
+        """
+        Put the request user into the form constructor kwargs so it can use it.
+        """
+        kwargs = super().get_form_kwargs()
+        kwargs.update({'user': self.request.user})
+        return kwargs
+
+    def form_valid(self, form):
+        user = get_object_or_404(User.objects, username=self.kwargs['owner'])
+        projectqs = Project.objects.filter(owner=self.request.user)
+        project = get_object_or_404(projectqs, owner=user,
+                                    title=self.kwargs['title'])
+        data = form.cleaned_data
+        print(data)
+        project.clone(data['title'], data['clone_theme'], data['clone_pages'],
+                      data['clone_posts'], data['clone_plugins'])
+        ctx = {
+            'success_message': 'Project cloned!',
+            'return_message': 'Cloned project home',
+            'return_url': reverse('project_home',
+                                  kwargs={'owner': user.username,
+                                          'title': data['title']}),
         }
         return TemplateResponse(self.request, 'success.html', context=ctx)
 


### PR DESCRIPTION
Resolves #70.

This branch implements project cloning, with tests.  It adds:
- A clone project view, which is accessible from the account home.  It has you specify the new name as well as whether to clone the theme, pages, posts, and plugins.
- Tests for the clone project view.
- `clone()` method on each model that is part of a project (except Tags, since those are falling by the wayside).
- Tests for the project `clone()` method.

Some miscellaneous changes:
- I updated the account home view to have a similar table layout to the project home.  Each project has a duplicate and a delete button.
- I removed "delete project" from the project home, since putting it at the account home fits more with how we delete everything else.
- I added tooltips to each glyphicon in the tables at account home and project home, so users don't have to intuitively understand what an icon stands for.

This is pretty much ready to merge, pending approval.